### PR TITLE
Change Tauri window dimension

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -55,8 +55,10 @@
     "windows": [
       {
         "fullscreen": false,
-        "minHeight": 900,
-        "minWidth": 1600,
+        "height": 800,
+        "minHeight": 300,
+        "width": 1220,
+        "minWidth": 500,
         "resizable": true,
         "title": "Prem App"
       }


### PR DESCRIPTION
Start the app at 1220x800, and allow resize down until 500x300.