### PR TITLE
Display progress download when navigating away from Home and back

### DIFF
--- a/src/modules/service-detail/components/ServiceDetail.tsx
+++ b/src/modules/service-detail/components/ServiceDetail.tsx
@@ -17,7 +17,7 @@ import useInterfaces from "shared/hooks/useInterfaces";
 import arrow from "assets/images/arrow.svg";
 import UseScrollToTop from "shared/hooks/useScrollToTop";
 
-const ServiceDetail = () => {
+const ServiceDetail = ({ progress, download }: any) => {
   const queryClient = useQueryClient();
   const { serviceId } = useParams();
   const navigate = useNavigate();
@@ -68,6 +68,8 @@ const ServiceDetail = () => {
             interfaces={interfaces.filter((app) => service.interfaces?.includes(app.id))}
             needsUpdate={service.needsUpdate}
             memoryRequirements={service.modelInfo?.memoryRequirements}
+            progress={progress}
+            download={download}
           />
         </div>
       </div>

--- a/src/modules/service/api/downloadServiceStream.ts
+++ b/src/modules/service/api/downloadServiceStream.ts
@@ -1,8 +1,14 @@
-import { AxiosResponse } from "axios";
-import api from "shared/api/v1";
 import { DownloadMessage } from "../types";
-import { fetchEventSource } from "@microsoft/fetch-event-source";
 import { getBackendUrlFromStore } from "shared/store/setting";
+
+let eventSource: EventSource;
+const instantiateEventSource = (backendUrl: string, serviceId: string) => {
+  if (eventSource) {
+    return eventSource;
+  } else {
+    eventSource = new EventSource(`${backendUrl}v1/download-service-stream-sse/${serviceId}`);
+  }
+};
 
 const downloadServiceStream = async (
   serviceId: string,
@@ -12,10 +18,7 @@ const downloadServiceStream = async (
 ): Promise<void> => {
   const backendUrl = new URL(getBackendUrlFromStore());
   try {
-    //const response = await api.get(`v1/download-service/${serviceId}`);
-    //console.log(response);
-
-    const eventSource = new EventSource(`${backendUrl}v1/download-service-stream-sse/${serviceId}`);
+    instantiateEventSource(backendUrl.toString(), serviceId);
     eventSource.onmessage = (event) => {
       if (!event.data) return;
       try {
@@ -36,36 +39,8 @@ const downloadServiceStream = async (
       onError(err);
     };
     eventSource.onopen = (evt) => {
-      //evt.target?.addEventListener('message', (event) => { console.log('listener: message: ', event)})
       console.log("onopen", evt);
     };
-
-    /*     eventSource.onerror = (err: any) => {
-      console.log('error', err.data);
-    };
-    eventSource.onopen = (evt) => {
-      evt.target?.addEventListener('message', (event) => { console.log('listener: message: ', event)})
-      console.log('onopen', evt);
-    }; */
-
-    /* fetchEventSource(`${backendUrl}v1/download-service-stream/${serviceId}`, {
-      method: "GET",
-      signal: ctrl.signal,
-      onmessage: (event) => {
-        console.log(event, event.data);
-        const data = JSON.parse(event.data);
-        onMessage(data);
-      },
-      onerror: (err: any) => {
-        console.log(err);
-        return onError(err);
-      },
-      onopen: (response: Response) => {
-        console.log(response);
-        console.log("stream opened");
-        return Promise.resolve();
-      }
-    }); */
   } catch (err) {
     console.log(err);
     onError(err);

--- a/src/modules/service/components/NeedsUpdateServiceState.tsx
+++ b/src/modules/service/components/NeedsUpdateServiceState.tsx
@@ -1,29 +1,27 @@
 import Spinner from "shared/components/Spinner";
 import { ServiceStateProps } from "../types";
 import RefreshIcon from "shared/components/RefreshIcon";
-import useDownloadServiceStream from "shared/hooks/useDownloadServiceStream";
 import useStartService from "shared/hooks/useStartService";
 import useStopService from "shared/hooks/useStopService";
 import { Tooltip } from "react-tooltip";
 
-const NeedsUpdateServiceState = ({ serviceId, refetch }: ServiceStateProps) => {
-  const { progress, download } = useDownloadServiceStream();
+const NeedsUpdateServiceState = ({ serviceId, refetch, progress, download }: ServiceStateProps) => {
   const { mutateAsync: startService, isLoading: isStartServiceLoading } = useStartService();
   const { mutateAsync: stopService, isLoading: isStopServiceLoading } = useStopService();
 
   const onDownload = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    download(serviceId, async () => {
+    download?.(serviceId, async () => {
       await stopService(serviceId);
       await startService(serviceId);
       refetch();
     });
   };
 
-  if (progress >= 0 || isStartServiceLoading || isStopServiceLoading) {
+  if ((progress && progress >= 0) || isStartServiceLoading || isStopServiceLoading) {
     return (
       <>
-        {progress > 0 && <p className="text-brightgray">{progress}%</p>}
+        {progress && progress > 0 && <p className="text-brightgray">{progress}%</p>}
         <div className="flex justify-center">
           <Spinner className="h-10 w-10" />
         </div>

--- a/src/modules/service/components/NotDownloadedServiceState.tsx
+++ b/src/modules/service/components/NotDownloadedServiceState.tsx
@@ -1,17 +1,25 @@
 import DownloadIcon from "shared/components/DownloadIcon";
 import Spinner from "shared/components/Spinner";
 import { ServiceStateProps } from "../types";
-import useDownloadServiceStream from "shared/hooks/useDownloadServiceStream";
+import useSettingStore from "../../../shared/store/setting";
 
-const NotDownloadedServiceState = ({ serviceId, refetch }: ServiceStateProps) => {
-  const { progress, download } = useDownloadServiceStream();
+const NotDownloadedServiceState = ({
+  serviceId,
+  refetch,
+  progress,
+  download,
+}: ServiceStateProps) => {
+  const addServiceDownloadInProgress = useSettingStore(
+    (state) => state.addServiceDownloadInProgress
+  );
 
   const onDownload = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    download(serviceId, refetch);
+    download?.(serviceId, refetch);
+    addServiceDownloadInProgress(serviceId);
   };
 
-  if (progress >= 0) {
+  if (progress && progress >= 0) {
     return (
       <>
         <p className="text-brightgray">{progress}%</p>

--- a/src/modules/service/components/Service.tsx
+++ b/src/modules/service/components/Service.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import AppContainer from "shared/components/AppContainer";
 import SearchFilter from "./SearchFilter";
 import { useParams } from "react-router-dom";
@@ -8,12 +8,19 @@ import useServices from "shared/hooks/useServices";
 import ServiceCard from "./ServiceCard";
 import { isDeveloperMode } from "shared/helpers/utils";
 import CustomServiceCard from "./CustomServiceCard";
+import useSettingStore from "../../../shared/store/setting";
+import useDownloadServiceStream from "../../../shared/hooks/useDownloadServiceStream";
 
 const Service = () => {
   const { appId } = useParams();
 
   const { data: response, isLoading: isServicesLoading, refetch: refetchServices } = useServices();
   const { data: appResponse } = useInterfaces();
+  const serviceDownloadsInProgress = useSettingStore((state) => state.serviceDownloadsInProgress);
+  const removeServiceDownloadInProgress = useSettingStore(
+    (state) => state.removeServiceDownloadInProgress
+  );
+  const { download, progresses } = useDownloadServiceStream();
 
   const [filter, setFilter] = useState(new Map<string, boolean>());
 
@@ -28,6 +35,49 @@ const Service = () => {
 
   const isDevMode = isDeveloperMode();
 
+  useEffect(() => {
+    serviceDownloadsInProgress.forEach((serviceId) => {
+      const afterSuccess = () => {
+        removeServiceDownloadInProgress(serviceId);
+        refetchServices();
+      };
+      download(serviceId, afterSuccess);
+    });
+  }, [serviceDownloadsInProgress.length]);
+
+  const ServicesComponents = useMemo(() => {
+    return filteredApps.map((app) => {
+      const filteredServices = services.filter((service) => service.interfaces.includes(app.id));
+      return (
+        <div key={app.id} className="mt-10">
+          <h3 className="text-brightgray font-bold md:text-xl maxMd:text-sm text-base flex md:mb-5 mb-[13px]">
+            {app.name}
+          </h3>
+          <div className="flex gap-[22px] flex-wrap ">
+            {filteredServices.map((service, index) => (
+              <ServiceCard
+                key={`${service.id}_${index}`}
+                icon={service.icon}
+                className={clsx("dashboard-bottom__card flex-wrap", {
+                  "services-running": service.running,
+                })}
+                service={service}
+                progress={progresses[service.id]}
+                download={download}
+              />
+            ))}
+
+            {!isServicesLoading && filteredServices.length === 0 && (
+              <div className="text-white opacity-70">No services found</div>
+            )}
+            {isServicesLoading && <div className="text-center text-[#8C8C8C]">Loading...</div>}
+            {isDevMode && <CustomServiceCard />}
+          </div>
+        </div>
+      );
+    });
+  }, [JSON.stringify(progresses), filteredApps.length]);
+
   return (
     <AppContainer>
       <div className="mask-heading mb-5 md:-mx-6 xl:-mx-10">
@@ -38,34 +88,7 @@ const Service = () => {
         <SearchFilter onFilterChange={setFilter} appId={appId as string} apps={apps} />
       )}
 
-      {filteredApps.map((app) => {
-        const filteredServices = services.filter((service) => service.interfaces.includes(app.id));
-        return (
-          <div key={app.id} className="mt-10">
-            <h3 className="text-brightgray font-bold md:text-xl maxMd:text-sm text-base flex md:mb-5 mb-[13px]">
-              {app.name}
-            </h3>
-            <div className="flex gap-[22px] flex-wrap ">
-              {filteredServices.map((service, index) => (
-                <ServiceCard
-                  key={`${service.id}_${index}`}
-                  icon={service.icon}
-                  className={clsx("dashboard-bottom__card flex-wrap", {
-                    "services-running": service.running,
-                  })}
-                  service={service}
-                />
-              ))}
-
-              {!isServicesLoading && filteredServices.length === 0 && (
-                <div className="text-white opacity-70">No services found</div>
-              )}
-              {isServicesLoading && <div className="text-center text-[#8C8C8C]">Loading...</div>}
-              {isDevMode && <CustomServiceCard />}
-            </div>
-          </div>
-        );
-      })}
+      {ServicesComponents}
     </AppContainer>
   );
 };

--- a/src/modules/service/components/ServiceActions.tsx
+++ b/src/modules/service/components/ServiceActions.tsx
@@ -19,6 +19,8 @@ const ServiceActions = ({
   interfaces,
   needsUpdate,
   memoryRequirements,
+  progress,
+  download,
 }: ServiceActionsProps) => {
   const navigate = useNavigate();
   const [modalIsOpen, setIsOpen] = useState(false);
@@ -49,7 +51,12 @@ const ServiceActions = ({
       <div className="flex flex-wrap items-center md:gap-4 gap-3 ml-auto">
         {children}
         {isDetailView && needsUpdate && (
-          <NeedsUpdateServiceState serviceId={serviceId} refetch={refetch} />
+          <NeedsUpdateServiceState
+            serviceId={serviceId}
+            refetch={refetch}
+            download={download}
+            progress={progress}
+          />
         )}
         {status === "running" && (
           <RunningServiceState
@@ -69,7 +76,12 @@ const ServiceActions = ({
         )}
 
         {status === "not_downloaded" && (
-          <NotDownloadedServiceState serviceId={serviceId} refetch={refetch} />
+          <NotDownloadedServiceState
+            serviceId={serviceId}
+            refetch={refetch}
+            download={download}
+            progress={progress}
+          />
         )}
 
         {["not_supported", "not_enough_memory", "not_enough_system_memory", "coming_soon"].includes(

--- a/src/modules/service/components/ServiceCard.tsx
+++ b/src/modules/service/components/ServiceCard.tsx
@@ -10,7 +10,7 @@ import useInterfaces from "shared/hooks/useInterfaces";
 import clsx from "clsx";
 import Beta from "./Beta";
 
-const ServiceCard = ({ className, icon, service }: ServiceCardProps) => {
+const ServiceCard = ({ className, icon, service, progress, download }: ServiceCardProps) => {
   const queryClient = useQueryClient();
 
   const serviceId = service.id;
@@ -40,6 +40,8 @@ const ServiceCard = ({ className, icon, service }: ServiceCardProps) => {
           interfaces={interfaces.filter((app) => service.interfaces?.includes(app.id))}
           needsUpdate={service.needsUpdate}
           memoryRequirements={service.modelInfo?.memoryRequirements}
+          progress={progress}
+          download={download}
         />
       </div>
       <h3>

--- a/src/modules/service/types.ts
+++ b/src/modules/service/types.ts
@@ -88,6 +88,8 @@ export type DownloadMessage = {
 export type ServiceStateProps = {
   serviceId: string;
   refetch: () => void;
+  progress?: number;
+  download?: (serviceId: string, refetch: any) => void;
   isDetailView?: boolean;
   onOpenClick?: () => void;
 };
@@ -105,6 +107,8 @@ export type ServiceCardProps = {
   className: string;
   icon: string;
   service: Service;
+  progress: number;
+  download: (serviceId: string, refetch: any) => void;
 };
 
 export type ServiceActionsProps = PropsWithChildren<{
@@ -115,6 +119,8 @@ export type ServiceActionsProps = PropsWithChildren<{
   interfaces: App[];
   needsUpdate: boolean;
   memoryRequirements: number;
+  progress: number;
+  download: (serviceId: string, refetch: any) => void;
 }>;
 
 export type WarningServiceStateProps = {

--- a/src/shared/hooks/useDownloadServiceStream.ts
+++ b/src/shared/hooks/useDownloadServiceStream.ts
@@ -1,8 +1,10 @@
 import downloadServiceStream from "modules/service/api/downloadServiceStream";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 const useDownloadServiceStream = () => {
-  const [progress, setProgress] = useState(-1);
+  const [progresses, setProgress] = useState<Record<string, number>>(() => ({}));
+  const progressesRef = useRef<Record<string, number>>({});
+
   const download = useCallback((serviceId: string, afterSuccess?: () => void) => {
     downloadServiceStream(
       serviceId,
@@ -11,16 +13,17 @@ const useDownloadServiceStream = () => {
       },
       (message) => {
         console.log(message.status);
-        if ("percentage" in message) setProgress(message.percentage as number);
+        progressesRef.current = { ...progressesRef.current, [serviceId]: message.percentage };
+        if ("percentage" in message) setProgress(progressesRef.current);
       },
       () => {
-        setProgress(-1);
+        setProgress({ ...progresses, [serviceId]: -1 });
         afterSuccess && afterSuccess();
       }
     );
   }, []);
 
-  return { progress, download };
+  return { progresses: progressesRef.current, download };
 };
 
 export default useDownloadServiceStream;

--- a/src/shared/store/setting.ts
+++ b/src/shared/store/setting.ts
@@ -9,7 +9,29 @@ const useSettingStore = create<SettingStore>()(
     persist(
       (set) => ({
         backendUrl: getBackendUrl(),
-        setBackendUrl: (backendUrl) => set(() => ({ backendUrl })),
+        serviceDownloadsInProgress: [],
+        addServiceDownloadInProgress: (serviceId) => {
+          set(
+            (state) => {
+              if (!state.serviceDownloadsInProgress.includes(serviceId)) {
+                state.serviceDownloadsInProgress.push(serviceId);
+              }
+              return { serviceDownloadsInProgress: state.serviceDownloadsInProgress };
+            },
+            false,
+            "addServiceDownloadInProgress"
+          );
+        },
+        removeServiceDownloadInProgress: (serviceId) => {
+          set((state) => {
+            const index = state.serviceDownloadsInProgress.indexOf(serviceId);
+            if (index > -1) {
+              state.serviceDownloadsInProgress.splice(index, 1);
+            }
+            return { serviceDownloadsInProgress: state.serviceDownloadsInProgress };
+          });
+        },
+        setBackendUrl: (backendUrl) => set(() => ({ backendUrl }), false, "setBackendUrl"),
       }),
       {
         name: "setting",

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -79,7 +79,10 @@ export type MarkdownProps = {
 
 export type SettingStore = {
   backendUrl: string;
+  serviceDownloadsInProgress: string[];
   setBackendUrl: (backendUrl: string) => void;
+  addServiceDownloadInProgress: (serviceId: string) => void;
+  removeServiceDownloadInProgress: (serviceId: string) => void;
 };
 
 export type HeaderProps = {


### PR DESCRIPTION
It fixes #255
It fixes #248 

The idea is to call `download` when Service page (Home) is mounting with any ServiceId that is in progress.
Should be tested with running this PR https://github.com/premAI-io/prem-daemon/pull/93 as daemon.

It currently works as you can see here https://www.loom.com/share/d8c423e56dc2429ebd21407c5676ced4?sid=24781c58-c528-47cf-8c05-746b5585f61a, but I suspect there might be some other bugs to catch, and it may be cleaner.
Please @jigneshsolanki, try to finish this PR.

@tiero @filopedraz  
