### PR TITLE
Dockerfile for standalone deployment & fix exporting VITE_BACKEND_URL

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,15 +1,8 @@
-:8000 {
-    handle_path /api/* {
-        reverse_proxy premd:8000
-    }
-    reverse_proxy prem_app:1420
-    header Access-Control-Allow-Origin *
-    header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
-    header Access-Control-Allow-Headers "Origin, X-Requested-With, Content-Type, Accept"
-}
-
-:1420 {
+:8080 {
     file_server {
         root /usr/share/caddy/html
     }
+    header Access-Control-Allow-Origin *
+    header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
+    header Access-Control-Allow-Headers "Origin, X-Requested-With, Content-Type, Accept"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ FROM caddy:alpine
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /app/dist /usr/share/caddy/html
 
-EXPOSE 8000
 # Add the script to patch window with ENV vars
 # https://create-react-app.dev/docs/title-and-meta-tags#injecting-data-from-the-server-into-the-page
 COPY entrypoint.sh /prem-entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,18 +6,19 @@ services:
     build: .
     environment:
       VITE_DESTINATION: browser
-      VITE_IS_PACKAGED: 'true'
-      VITE_BACKEND_URL: http://localhost:8000/api
+      VITE_IS_PACKAGED: 'false'
+      VITE_BACKEND_URL: http://localhost:8000
       VITE_DEVELOPER_MODE: 0
     ports:
-      - 8000:8000
+      - 8080:8080
 
   premd:
     container_name: premd
-    image: ghcr.io/premai-io/premd:v0.0.22
+    image: ghcr.io/premai-io/premd:v0.0.23
     restart: on-failure
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       PREM_REGISTRY_URL: https://raw.githubusercontent.com/premAI-io/prem-registry/main/manifests.json
-      SENTRY_DSN: https://75592545ad6b472e9ad7c8ff51740b73@o1068608.ingest.sentry.io/4505244431941632
+    ports:
+      - 8000:8000

--- a/src/shared/store/setting.ts
+++ b/src/shared/store/setting.ts
@@ -7,7 +7,7 @@ import { createJSONStorage, devtools, persist } from "zustand/middleware";
 export const getBackendUrl = () => {
   let backendURL = "http://localhost:54321";
   if (isBackendSet()) {
-    backendURL = import.meta.env.VITE_BACKEND_URL;
+    backendURL = (window as any).VITE_BACKEND_URL || import.meta.env.VITE_BACKEND_URL;
   }
   if (isPackaged()) {
     backendURL = `${window.location.protocol}//${window.location.host}/api/`;


### PR DESCRIPTION
I did this to allow deployment of the Prem App as a standalone application, without forcing a specific web server setup (ie. assuming prem daemon will be run at the same time on same host) and using IS_PACKAGED

The docker-compose serves as "reference" for how to deploy things, but this way the Dockerfile and the Caddyfile can work without assuming where and how the daemon will be deployed and served.

I am open to exploring how to retain the current version where we run the app and daemon together, kind of replicate the `IS_PACKAGED` solution used in `prem-box` (which FYI will be deprecated soon in favor of `prem-gateway`)