### PR TITLE
fix exporting window.VITE_BACKEND_URL if isBackendSet

### DIFF
--- a/src/shared/store/setting.ts
+++ b/src/shared/store/setting.ts
@@ -7,7 +7,7 @@ import { createJSONStorage, devtools, persist } from "zustand/middleware";
 export const getBackendUrl = () => {
   let backendURL = "http://localhost:54321";
   if (isBackendSet()) {
-    backendURL = import.meta.env.VITE_BACKEND_URL;
+    backendURL = (window as any).VITE_BACKEND_URL || import.meta.env.VITE_BACKEND_URL;
   }
   if (isPackaged()) {
     backendURL = `${window.location.protocol}//${window.location.host}/api/`;


### PR DESCRIPTION
This fixes problem found doing the #338 PR. I did it here also in isolation in case that PR will not be merged.