### PR TITLE
download

### DIFF
--- a/src-tauri/src/controller_binaries.rs
+++ b/src-tauri/src/controller_binaries.rs
@@ -1,6 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::download::Downloader;
@@ -12,7 +13,7 @@ use tokio::{fs, process::Command};
 
 #[tauri::command(async)]
 pub async fn download_service<R: Runtime>(
-    binary_url: String,
+    binaries_url: HashMap<String, Option<String>>,
     weights_directory_url: String,
     weights_files: Vec<String>,
     service_id: &str,
@@ -32,7 +33,7 @@ pub async fn download_service<R: Runtime>(
     };
 
     Downloader::new(
-        binary_url,
+        binaries_url,
         weights_directory_url,
         weights_files,
         service_id,

--- a/src-tauri/src/controller_binaries.rs
+++ b/src-tauri/src/controller_binaries.rs
@@ -12,8 +12,9 @@ use tokio::{fs, process::Command};
 
 #[tauri::command(async)]
 pub async fn download_service<R: Runtime>(
-    hugging_face_id: &str,
-    model_files: Vec<String>,
+    binary_url: String,
+    weights_directory_url: String,
+    weights_files: Vec<String>,
     service_id: &str,
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, SharedState>,
@@ -23,7 +24,7 @@ pub async fn download_service<R: Runtime>(
         .path_resolver()
         .app_data_dir()
         .expect("failed to resolve app data dir")
-        .join("binaries")
+        .join("models")
         .join(&service_id);
 
     let Some(service_dir) = service_dir.to_str() else {
@@ -31,13 +32,14 @@ pub async fn download_service<R: Runtime>(
     };
 
     Downloader::new(
-        hugging_face_id,
-        model_files,
+        binary_url,
+        weights_directory_url,
+        weights_files,
         service_id,
         service_dir,
         window,
     )
-    .download_ggml_files()
+    .download_files()
     .await?;
 
     let mut registry_lock = state.services.lock().await;

--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -3,33 +3,15 @@ use crate::errors::{Context, Result};
 use futures::StreamExt;
 use serde::Serialize;
 use tauri::{Runtime, Window};
-use tokio::fs::OpenOptions;
+use tokio::fs::{File, OpenOptions};
 use tokio::io::AsyncWriteExt;
 
-pub enum Registry {
-    HuggingFace,
-    // add other registries
-    // OtherRegistry
-}
-impl Registry {
-    fn build_download_url(&self, hugging_face_id: &str, file: &str) -> String {
-        match self {
-            Registry::HuggingFace => format!(
-                "https://huggingface.co/{}/resolve/main/{}",
-                hugging_face_id, file
-            ),
-            // add other registry path support
-            // Registry::OtherRegistry => format!("other-registry-url")
-        }
-    }
-}
-
 pub struct Downloader<R: Runtime> {
-    hugging_face_id: String,
-    model_files: Vec<String>,
+    binary_url: String,
+    weights_directory_url: String,
+    weights_files: Vec<String>,
     service_id: String,
     service_dir: String,
-    registry: Registry,
     window: Window<R>,
 }
 
@@ -43,47 +25,51 @@ struct ProgressPayload {
 
 impl<R: Runtime> Downloader<R> {
     pub fn new(
-        hugging_face_id: impl AsRef<str>,
-        model_files: Vec<String>,
+        binary_url: impl AsRef<str>,
+        weights_directory_url: impl AsRef<str>,
+        weights_files: Vec<String>,
         service_id: impl AsRef<str>,
         service_dir: impl AsRef<str>,
         window: Window<R>,
     ) -> Self {
         Self {
-            hugging_face_id: hugging_face_id.as_ref().to_string(),
-            model_files: model_files.to_vec(),
+            binary_url: binary_url.as_ref().to_string(),
+            weights_directory_url: weights_directory_url.as_ref().to_string(),
+            weights_files: weights_files.to_vec(),
             service_id: service_id.as_ref().to_string(),
             service_dir: service_dir.as_ref().to_string(),
-            registry: Registry::HuggingFace,
             window,
         }
     }
 
-    pub async fn download_ggml_files(&self) -> Result<()> {
-        self.download_files(&self.model_files).await
+    pub async fn download_files(&self) -> Result<()> {
+        self.download_binary().await?;
+        self.download_weights_files().await
     }
 
-    async fn download_files(&self, files: &[impl AsRef<str>]) -> Result<()> {
-        futures::future::join_all(files.into_iter().map(|filename| {
-            let url = self
-                .registry
-                .build_download_url(&self.hugging_face_id, filename.as_ref());
-            self.download_file(url, format!("{}/{}", self.service_dir, filename.as_ref()))
+    async fn download_weights_files(&self) -> Result<()> {
+        futures::future::join_all(self.weights_files.clone().into_iter().map(|filename| {
+            let url = format!("{}{}", &self.weights_directory_url, filename);
+            self.download_weight_file(url, format!("{}/{}", &self.service_dir, filename))
         }))
         .await
         .into_iter()
         .collect()
     }
 
-    async fn download_file(&self, url: impl AsRef<str>, path: impl AsRef<str>) -> Result<()> {
+    async fn download_weight_file(
+        &self,
+        url: impl AsRef<str>,
+        output_path: impl AsRef<str>,
+    ) -> Result<()> {
         let mut size_on_disk: u64 = 0;
 
         // Check if there is a file on disk already.
-        if tokio::fs::metadata(path.as_ref()).await.is_ok() {
+        if tokio::fs::metadata(output_path.as_ref()).await.is_ok() {
             // If so, check file length to know where to restart the download from.
-            size_on_disk = tokio::fs::metadata(path.as_ref())
+            size_on_disk = tokio::fs::metadata(output_path.as_ref())
                 .await
-                .with_context(|| format!("Failed to get metadata for {}", path.as_ref()))?
+                .with_context(|| format!("Failed to get metadata for {}", output_path.as_ref()))?
                 .len();
         }
 
@@ -96,7 +82,13 @@ impl<R: Runtime> Downloader<R> {
             )
             .send()
             .await
-            .map_err(|_| format!("Failed to GET from {} to {}", url.as_ref(), path.as_ref()))
+            .map_err(|_| {
+                format!(
+                    "Failed to GET from {} to {}",
+                    url.as_ref(),
+                    output_path.as_ref()
+                )
+            })
             .unwrap();
 
         // Check the status for errors.
@@ -115,8 +107,8 @@ impl<R: Runtime> Downloader<R> {
         }
 
         // Prepare the destination directories
-        if let Some(last_slash) = path.as_ref().rfind('/') {
-            let dirs = &path.as_ref()[..last_slash];
+        if let Some(last_slash) = output_path.as_ref().rfind('/') {
+            let dirs = &output_path.as_ref()[..last_slash];
             if let Err(e) = tokio::fs::create_dir_all(dirs).await {
                 println!("Error creating directory: {:?}", e);
             } else {
@@ -131,9 +123,9 @@ impl<R: Runtime> Downloader<R> {
             .create(true)
             .write(true)
             .append(true)
-            .open(path.as_ref())
+            .open(output_path.as_ref())
             .await
-            .with_context(|| format!("Failed to create file at: {}", path.as_ref()))?;
+            .with_context(|| format!("Failed to create file at: {}", output_path.as_ref()))?;
 
         // Download the file chunk by chunk.
         let mut downloaded_size = size_on_disk;
@@ -150,14 +142,14 @@ impl<R: Runtime> Downloader<R> {
 
             downloaded_size += chunk_size;
             // Write the chunk to disk.
-            file.write_all_buf(&mut chunk)
-                .await
-                .with_context(|| format!("Failed to write to destination {}", path.as_ref()))?;
+            file.write_all_buf(&mut chunk).await.with_context(|| {
+                format!("Failed to write to destination {}", output_path.as_ref())
+            })?;
 
             // Emit progress to JS
             println!(
                 "{} - bytes downloaded: {}, out of: {}",
-                path.as_ref(),
+                output_path.as_ref(),
                 downloaded_size,
                 total_file_size,
             );
@@ -165,7 +157,7 @@ impl<R: Runtime> Downloader<R> {
                 .emit(
                     "progress_bar_download_update",
                     ProgressPayload {
-                        path: path.as_ref().to_string(),
+                        path: output_path.as_ref().to_string(),
                         service_id: self.service_id.clone(),
                         downloaded: downloaded_size,
                         total: total_file_size,
@@ -173,6 +165,53 @@ impl<R: Runtime> Downloader<R> {
                 )
                 .with_context(|| "Failed to emit event")?;
         }
+        Ok(())
+    }
+
+    pub async fn download_binary(&self) -> Result<()> {
+        let response = reqwest::get(&self.binary_url)
+            .await
+            .expect("Failed to download binary");
+
+        let binary_name = self.binary_url.split('/').last().unwrap();
+        let output_path = format!("{}/{}", self.service_dir, binary_name);
+
+        // Prepare the destination directories
+        if let Some(last_slash) = output_path.rfind('/') {
+            let dirs = &output_path[..last_slash];
+            if let Err(e) = tokio::fs::create_dir_all(dirs).await {
+                println!("Error creating directory: {:?}", e);
+            } else {
+                println!("Directory created successfully or already exists");
+            }
+        } else {
+            println!("No '/' found in the input string.");
+        }
+
+        if !response.status().is_success() {
+            Err(format!(
+                "GET Request: ({}): ({})",
+                response.status(),
+                self.binary_url
+            ))?
+        }
+
+        let mut file = File::create(&output_path.as_str()).await.unwrap();
+        file.write(&response.bytes().await.unwrap())
+            .await
+            .with_context(|| format!("Failed to write to {}", output_path))?;
+        self.set_permission(output_path).await?;
+        Ok(())
+    }
+
+    async fn set_permission(&self, binary_path: impl AsRef<str>) -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(binary_path.as_ref())
+            .with_context(|| format!("Failed to get metadata for {}", binary_path.as_ref()))?
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(binary_path.as_ref(), permissions)
+            .with_context(|| format!("Failed to set permissions for {}", binary_path.as_ref()))?;
         Ok(())
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -52,12 +52,12 @@ pub struct Service {
     #[serde(rename = "serviceType")]
     service_type: Option<String>, //"binary" | "process",
     version: Option<String>,
-    #[serde(rename = "huggingFaceId")]
-    hugging_face_id: Option<String>,
-    #[serde(rename = "modelFiles")]
-    model_files: Option<Vec<String>>,
-    #[serde(rename = "weightsUrl")]
-    weights_url: Option<String>,
+    #[serde(rename = "weightsDirectoryUrl")]
+    weights_directory_url: Option<String>,
+    #[serde(rename = "weightsFiles")]
+    weights_files: Option<Vec<String>>,
+    #[serde(rename = "binariesUrl")]
+    binaries_url: Option<HashMap<String, Option<String>>>,
     #[serde(rename = "serveCommand")]
     serve_command: Option<String>,
 }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -18,3 +18,11 @@ pub async fn add_services_from_registry(
     }
     Ok(())
 }
+
+pub fn is_aarch64() -> bool {
+    cfg!(target_arch = "aarch64")
+}
+
+pub fn is_x86_64() -> bool {
+    cfg!(target_arch = "x86_64")
+}

--- a/src/controller/abstractServiceController.ts
+++ b/src/controller/abstractServiceController.ts
@@ -5,7 +5,13 @@ abstract class AbstractServiceController {
   abstract restart(serviceId: string): void;
   abstract stop(serviceId: string): void;
   abstract delete(serviceId: string): void;
-  abstract download({ serviceId, huggingFaceId, modelFiles, afterSuccess }: DownloadArgs): void;
+  abstract download({
+    serviceId,
+    binaryUrl,
+    weightsDirectoryUrl,
+    weightsFiles,
+    afterSuccess,
+  }: DownloadArgs): void;
   abstract getService(serviceId: string): void;
   abstract getServices(): void;
   abstract getLogs(serviceId: string): void;

--- a/src/controller/abstractServiceController.ts
+++ b/src/controller/abstractServiceController.ts
@@ -7,7 +7,7 @@ abstract class AbstractServiceController {
   abstract delete(serviceId: string): void;
   abstract download({
     serviceId,
-    binaryUrl,
+    binariesUrl,
     weightsDirectoryUrl,
     weightsFiles,
     afterSuccess,

--- a/src/controller/binariesController.ts
+++ b/src/controller/binariesController.ts
@@ -47,20 +47,25 @@ class BinariesController extends AbstractServiceController {
 
   async download({
     serviceId,
-    binaryUrl,
+    binariesUrl,
     weightsDirectoryUrl,
     weightsFiles,
     afterSuccess,
   }: {
     serviceId: string;
-    binaryUrl?: string;
+    binariesUrl?: Record<string, string | null>;
     weightsDirectoryUrl?: string;
     weightsFiles?: string[];
     afterSuccess?: () => void;
   }): Promise<void> {
     console.log(`Downloading service ${serviceId}`);
     try {
-      await invoke("download_service", { binaryUrl, weightsDirectoryUrl, weightsFiles, serviceId });
+      await invoke("download_service", {
+        binariesUrl,
+        weightsDirectoryUrl,
+        weightsFiles,
+        serviceId,
+      });
       afterSuccess?.();
     } catch (e) {
       console.log(e);

--- a/src/controller/binariesController.ts
+++ b/src/controller/binariesController.ts
@@ -47,18 +47,20 @@ class BinariesController extends AbstractServiceController {
 
   async download({
     serviceId,
-    huggingFaceId,
-    modelFiles,
+    binaryUrl,
+    weightsDirectoryUrl,
+    weightsFiles,
     afterSuccess,
   }: {
     serviceId: string;
-    huggingFaceId?: string;
-    modelFiles?: string[];
+    binaryUrl?: string;
+    weightsDirectoryUrl?: string;
+    weightsFiles?: string[];
     afterSuccess?: () => void;
   }): Promise<void> {
     console.log(`Downloading service ${serviceId}`);
     try {
-      await invoke("download_service", { serviceId, huggingFaceId, modelFiles });
+      await invoke("download_service", { binaryUrl, weightsDirectoryUrl, weightsFiles, serviceId });
       afterSuccess?.();
     } catch (e) {
       console.log(e);

--- a/src/controller/serviceController.ts
+++ b/src/controller/serviceController.ts
@@ -5,8 +5,9 @@ import DockerController from "./dockerController";
 
 export type DownloadArgs = {
   serviceId: string;
-  huggingFaceId?: string;
-  modelFiles?: string[];
+  binaryUrl?: string;
+  weightsDirectoryUrl?: string;
+  weightsFiles?: string[];
   afterSuccess?: () => void;
 };
 
@@ -17,8 +18,8 @@ interface IServiceController {
   delete(serviceId: string, serviceType: string): Promise<void>;
   download({
     serviceId,
-    huggingFaceId,
-    modelFiles,
+    weightsDirectoryUrl,
+    weightsFiles,
     serviceType,
     afterSuccess,
   }: DownloadArgs & { serviceType: string }): Promise<void>;
@@ -85,8 +86,9 @@ class ServiceController implements IServiceController {
 
   async download({
     serviceId,
-    huggingFaceId,
-    modelFiles,
+    binaryUrl,
+    weightsDirectoryUrl,
+    weightsFiles,
     serviceType,
     afterSuccess,
   }: DownloadArgs & { serviceType: string }): Promise<void> {
@@ -97,8 +99,9 @@ class ServiceController implements IServiceController {
     } else if (serviceType === "binary") {
       await this.binariesController.download({
         serviceId,
-        huggingFaceId,
-        modelFiles,
+        binaryUrl,
+        weightsDirectoryUrl,
+        weightsFiles,
         afterSuccess,
       });
     }

--- a/src/controller/serviceController.ts
+++ b/src/controller/serviceController.ts
@@ -5,7 +5,7 @@ import DockerController from "./dockerController";
 
 export type DownloadArgs = {
   serviceId: string;
-  binaryUrl?: string;
+  binariesUrl?: Record<string, string | null>;
   weightsDirectoryUrl?: string;
   weightsFiles?: string[];
   afterSuccess?: () => void;
@@ -86,7 +86,7 @@ class ServiceController implements IServiceController {
 
   async download({
     serviceId,
-    binaryUrl,
+    binariesUrl,
     weightsDirectoryUrl,
     weightsFiles,
     serviceType,
@@ -99,7 +99,7 @@ class ServiceController implements IServiceController {
     } else if (serviceType === "binary") {
       await this.binariesController.download({
         serviceId,
-        binaryUrl,
+        binariesUrl,
         weightsDirectoryUrl,
         weightsFiles,
         afterSuccess,

--- a/src/modules/service/components/NotDownloadedServiceState.tsx
+++ b/src/modules/service/components/NotDownloadedServiceState.tsx
@@ -12,8 +12,10 @@ const NotDownloadedServiceState = ({ service, refetch, progress }: ServiceStateP
     e.preventDefault();
     download?.({
       serviceId: service.id,
-      huggingFaceId: isServiceBinary(service) ? service.huggingFaceId : undefined,
-      modelFiles: isServiceBinary(service) ? service.modelFiles : undefined,
+      // TODO: determine the correct binary url based on the current platform
+      binaryUrl: isServiceBinary(service) ? service.binariesUrl["aarch64-apple-darwin"] : undefined,
+      weightsDirectoryUrl: isServiceBinary(service) ? service.weightsDirectoryUrl : undefined,
+      weightsFiles: isServiceBinary(service) ? service.weightsFiles : undefined,
       serviceType: service.serviceType,
       afterSuccess: () => {
         useSettingStore.getState().removeServiceDownloadInProgress(service.id);

--- a/src/modules/service/components/NotDownloadedServiceState.tsx
+++ b/src/modules/service/components/NotDownloadedServiceState.tsx
@@ -12,8 +12,7 @@ const NotDownloadedServiceState = ({ service, refetch, progress }: ServiceStateP
     e.preventDefault();
     download?.({
       serviceId: service.id,
-      // TODO: determine the correct binary url based on the current platform
-      binaryUrl: isServiceBinary(service) ? service.binariesUrl["aarch64-apple-darwin"] : undefined,
+      binariesUrl: isServiceBinary(service) ? service.binariesUrl : undefined,
       weightsDirectoryUrl: isServiceBinary(service) ? service.weightsDirectoryUrl : undefined,
       weightsFiles: isServiceBinary(service) ? service.weightsFiles : undefined,
       serviceType: service.serviceType,

--- a/src/modules/service/components/Service.tsx
+++ b/src/modules/service/components/Service.tsx
@@ -45,8 +45,13 @@ const Service = () => {
           if (service && Object.keys(service ?? {}).length) {
             download({
               serviceId,
-              huggingFaceId: isServiceBinary(service) ? service.huggingFaceId : undefined,
-              modelFiles: isServiceBinary(service) ? service.modelFiles : undefined,
+              binaryUrl: isServiceBinary(service)
+                ? service.binariesUrl["aarch64-apple-darwin"]
+                : undefined,
+              weightsDirectoryUrl: isServiceBinary(service)
+                ? service.weightsDirectoryUrl
+                : undefined,
+              weightsFiles: isServiceBinary(service) ? service.weightsFiles : undefined,
               serviceType: service.serviceType ?? "",
               afterSuccess: async () => {
                 useSettingStore.getState().removeServiceDownloadInProgress(serviceId);

--- a/src/modules/service/components/Service.tsx
+++ b/src/modules/service/components/Service.tsx
@@ -45,9 +45,7 @@ const Service = () => {
           if (service && Object.keys(service ?? {}).length) {
             download({
               serviceId,
-              binaryUrl: isServiceBinary(service)
-                ? service.binariesUrl["aarch64-apple-darwin"]
-                : undefined,
+              binariesUrl: isServiceBinary(service) ? service.binariesUrl : undefined,
               weightsDirectoryUrl: isServiceBinary(service)
                 ? service.weightsDirectoryUrl
                 : undefined,

--- a/src/modules/service/components/ServiceActions.tsx
+++ b/src/modules/service/components/ServiceActions.tsx
@@ -119,7 +119,7 @@ const ServiceActions = ({
     e.preventDefault();
     download({
       serviceId: service.id,
-      binaryUrl: isServiceBinary(service) ? service.binariesUrl["aarch64-apple-darwin"] : undefined,
+      binariesUrl: isServiceBinary(service) ? service.binariesUrl : undefined,
       weightsDirectoryUrl: isServiceBinary(service) ? service.weightsDirectoryUrl : undefined,
       weightsFiles: isServiceBinary(service) ? service.weightsFiles : undefined,
       serviceType: service.serviceType,

--- a/src/modules/service/components/ServiceActions.tsx
+++ b/src/modules/service/components/ServiceActions.tsx
@@ -119,8 +119,9 @@ const ServiceActions = ({
     e.preventDefault();
     download({
       serviceId: service.id,
-      huggingFaceId: isServiceBinary(service) ? service?.huggingFaceId : undefined,
-      modelFiles: isServiceBinary(service) ? service?.modelFiles : undefined,
+      binaryUrl: isServiceBinary(service) ? service.binariesUrl["aarch64-apple-darwin"] : undefined,
+      weightsDirectoryUrl: isServiceBinary(service) ? service.weightsDirectoryUrl : undefined,
+      weightsFiles: isServiceBinary(service) ? service.weightsFiles : undefined,
       serviceType: service.serviceType,
       afterSuccess: async () => {
         refetch();

--- a/src/modules/service/types.ts
+++ b/src/modules/service/types.ts
@@ -44,17 +44,18 @@ export type ServiceDocker = ServiceBase & {
 
 export type ServiceBinary = ServiceBase & {
   serviceType: "binary";
-  weightsUrl: string;
   serveCommand: string;
-  huggingFaceId: string;
   modelFiles: string[];
+  weightsDirectoryUrl: string;
+  weightsFiles: string[];
+  binariesUrl: {
+    "aarch64-apple-darwin"?: string;
+    "x86_64-apple-darwin"?: string;
+    "universal-apple-darwin"?: string;
+  };
 };
 
-export type ServiceProcess = ServiceBase & {
-  serviceType: "process";
-};
-
-export type Service = ServiceDocker | ServiceBinary | ServiceProcess;
+export type Service = ServiceDocker | ServiceBinary;
 
 export type SearchFilterProps = {
   apps: App[];

--- a/src/shared/hooks/useDownloadServiceStream.ts
+++ b/src/shared/hooks/useDownloadServiceStream.ts
@@ -8,7 +8,7 @@ const useDownloadServiceStream = () => {
   return useMutation(
     ({
       serviceId,
-      binaryUrl,
+      binariesUrl,
       weightsDirectoryUrl,
       weightsFiles,
       serviceType,
@@ -16,7 +16,7 @@ const useDownloadServiceStream = () => {
     }: DownloadArgs & { serviceType: string }) =>
       controller.download({
         serviceId,
-        binaryUrl,
+        binariesUrl,
         weightsDirectoryUrl,
         weightsFiles,
         serviceType,

--- a/src/shared/hooks/useDownloadServiceStream.ts
+++ b/src/shared/hooks/useDownloadServiceStream.ts
@@ -8,12 +8,20 @@ const useDownloadServiceStream = () => {
   return useMutation(
     ({
       serviceId,
-      huggingFaceId,
-      modelFiles,
+      binaryUrl,
+      weightsDirectoryUrl,
+      weightsFiles,
       serviceType,
       afterSuccess,
     }: DownloadArgs & { serviceType: string }) =>
-      controller.download({ serviceId, huggingFaceId, modelFiles, serviceType, afterSuccess }),
+      controller.download({
+        serviceId,
+        binaryUrl,
+        weightsDirectoryUrl,
+        weightsFiles,
+        serviceType,
+        afterSuccess,
+      }),
   );
 };
 


### PR DESCRIPTION
This PR is implementing the binary (Tabby cli in the case of Tabby) and weights files download using this schema:
```
{
    "id": "tabby-codellama-7B",
    "serviceType": "binary",
    "version": "1",
    "name": "Tabby CodeLlama 7B",
    "description": "",
    "documentation": "",
    "beta": true,
    "icon": "",
    "modelInfo": {
        "memoryRequirements": 3204
    },
    "interfaces": [
        "coder"
    ],
    "defaultPort": 8080,
    "defaultExternalPort": 10111,
    "weightsDirectoryUrl": "https://huggingface.co/TabbyML/CodeLlama-7B/resolve/main/",
    "weightsFiles": [
        "tabby.json",
        "tokenizer.json",
        "ggml/q8_0.gguf"
    ],
    "binariesUrl": {
        "aarch64-apple-darwin": "https://github.com/TabbyML/tabby/releases/download/v0.3.0/tabby_aarch64-apple-darwin",
        "x86_64-apple-darwin": null,
        "universal-apple-darwin": null
    },
    "serveCommand": "./tabby_aarch64-apple-darwin serve --model ./models/tabby-codellama-7B/ --device metal"
}
```

Everything is stored in $USER/Library/Application Support/prem.tauri.dev
<img width="963" alt="Screenshot 2023-10-17 at 16 41 18" src="https://github.com/premAI-io/prem-app/assets/4022128/b733ab27-66d5-40f4-9fe7-02ec7c6baed4">



