### PR TITLE
fix: load binary path during download

### DIFF
--- a/src-tauri/src/controller_binaries.rs
+++ b/src-tauri/src/controller_binaries.rs
@@ -21,6 +21,7 @@ pub async fn download_service<R: Runtime>(
     service_id: &str,
     app_handle: AppHandle,
     window: Window<R>,
+    state: State<'_, SharedState>,
 ) -> Result<()> {
     let service_dir = app_handle
         .path_resolver()
@@ -41,7 +42,7 @@ pub async fn download_service<R: Runtime>(
         service_dir,
         window,
     )
-    .download_files()
+    .download_files(state)
     .await?;
     Ok(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,7 +7,7 @@ mod errors;
 mod utils;
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 use tauri::{
     AboutMetadata, CustomMenuItem, Manager, Menu, MenuItem, RunEvent, Submenu, SystemTray,
     SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem, WindowEvent,
@@ -69,6 +69,7 @@ pub struct Service {
     enough_storage: Option<bool>,
     running: Option<bool>,
     supported: Option<bool>,
+    binary_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -106,6 +107,8 @@ fn main() {
         .filter_level(log::LevelFilter::Info)
         .parse_default_env()
         .init();
+
+    log::info!("Starting application.");
 
     let menu = Menu::new()
         .add_submenu(Submenu::new(


### PR DESCRIPTION
This cleansup the code a bit and uses binary path from download path rather than serve_command field of the manifest. 

This currently works with the manifest as it exists today but ignores, the binary path at the start of the serve command.

Will make a separate PR to handle variables in serveCommand/serveArgs.