### PR TITLE
fix: gracefully handle process kill

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -538,6 +538,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
+dependencies = [
+ "nix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2489,6 +2499,7 @@ name = "prem-app"
 version = "0.1.2"
 dependencies = [
  "chrono",
+ "ctrlc",
  "futures",
  "log",
  "pretty_env_logger",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -458,6 +458,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +662,12 @@ name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "embed-resource"
@@ -1976,6 +2006,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,6 +2497,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sys-info",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "thiserror",
@@ -2646,6 +2686,26 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3400,6 +3460,21 @@ checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.29.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a18d114d420ada3a891e6bc8e96a2023402203296a47cdd65083377dad18ba5"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,6 +12,7 @@
   sentry-tauri = "0.2"
   serde_json = "1.0"
   sys-info = "0.9.1"
+  sysinfo = "0.29.10"
   thiserror = "1.0.49"
 
   [dependencies.futures]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,6 +7,7 @@
 
 [dependencies]
   chrono = "0.4.31"
+  ctrlc = "3.4.1"
   log = "0.4.20"
   pretty_env_logger = "0.5.0"
   sentry-tauri = "0.2"

--- a/src-tauri/src/controller_binaries.rs
+++ b/src-tauri/src/controller_binaries.rs
@@ -173,7 +173,7 @@ pub async fn stop_service(service_id: String, state: State<'_, Arc<SharedState>>
     _stop_service(service_id.as_str(), running_services, services).await
 }
 
-pub async fn _stop_service(
+async fn _stop_service(
     service_id: &str,
     running_services: &Mutex<HashMap<String, Child>>,
     services: &Mutex<HashMap<String, Service>>,

--- a/src-tauri/src/controller_binaries.rs
+++ b/src-tauri/src/controller_binaries.rs
@@ -1,18 +1,27 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use crate::download::Downloader;
-use crate::errors::{Context, Result};
-use crate::{Service, SharedState};
+use crate::{
+    download::Downloader,
+    err,
+    errors::{Context, Result},
+    logerr, Service, SharedState,
+};
+
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
-use sys_info::mem_info;
 
 use futures::future;
+
+use sys_info::mem_info;
+use sysinfo::{Pid, ProcessExt, ProcessRefreshKind, RefreshKind, SystemExt};
+
 use tauri::{AppHandle, Runtime, State, Window};
+
+use tokio::fs;
+use tokio::process::Command;
 use tokio::time::interval;
-use tokio::{fs, process::Command};
 
 #[tauri::command(async)]
 pub async fn download_service<R: Runtime>(
@@ -71,7 +80,7 @@ pub async fn start_service(
     // Check if service is already running
     let running_services_guard = state.running_services.lock().await;
     if running_services_guard.contains_key(&service_id) {
-        Err(format!("Service with `{service_id}` already exist"))?
+        err!("Service with `{service_id}` already exist")
     }
     drop(running_services_guard);
 
@@ -95,7 +104,7 @@ pub async fn start_service(
     let binary_path = PathBuf::from(&service_dir).join(&serve_command_vec[0]);
     log::info!("binary_path: {:?}", binary_path);
     if !binary_path.exists() {
-        Err(format!("invalid binary for `{service_id}`"))?
+        err!("invalid binary for `{service_id}`")
     }
     // Extract the arguments with different delimiters
     let args: Vec<String> = serve_command_vec[1..]
@@ -160,15 +169,29 @@ pub async fn start_service(
 #[tauri::command(async)]
 pub async fn stop_service(service_id: String, state: State<'_, SharedState>) -> Result<()> {
     let mut running_services_guard = state.running_services.lock().await;
-    if let Some(mut child) = running_services_guard.remove(&service_id) {
-        match child.kill().await {
-            Ok(_) => {
-                log::info!("Child process killed: {}", service_id);
-            }
-            Err(e) => {
-                log::error!("Failed to kill child process: {}", e);
-            }
-        }
+    let Some(child) = running_services_guard.remove(&service_id) else {
+        err!("Service not running")
+    };
+    // kill the process gracefully using SIGTERM/SIGINT
+    let Some(pid) = child.id() else {
+        err!("Service couldn't be stopped: {}", service_id)
+    };
+    let system = sysinfo::System::new_with_specifics(
+        RefreshKind::new().with_processes(ProcessRefreshKind::new()),
+    );
+    let process = system
+        .process(Pid::from(pid as usize))
+        .with_context(|| format!("Process pid({}) invalid", pid))?;
+    log::info!(
+        "terminating service: process_name({}) process_id({})",
+        process.name(),
+        process.pid()
+    );
+    if !process
+        .kill_with(sysinfo::Signal::Term)
+        .with_context(|| format!("Couldn't send terminate signal to process(pid: {}).", pid))?
+    {
+        err!("Failed to kill the process");
     }
     let mut registry_lock = state.services.lock().await;
     if let Some(service) = registry_lock.get_mut(&service_id) {
@@ -181,7 +204,7 @@ pub fn stop_all_services(state: tauri::State<'_, SharedState>) {
     tauri::async_runtime::block_on(async move {
         let services = state.running_services.lock().await;
         for service_id in services.keys() {
-            _ = stop_service(service_id.clone(), state.clone()).await;
+            logerr!(stop_service(service_id.clone(), state.clone()).await);
         }
     })
 }
@@ -279,9 +302,9 @@ pub async fn is_service_downloaded(service: &Service, app_handle: &AppHandle) ->
     let service_dir = app_handle
         .path_resolver()
         .app_data_dir()
-        .expect("failed to resolve app data dir")
+        .with_context(|| "Failed to resolve app data dir")?
         .join("models")
-        .join(&service.id.as_ref().unwrap());
+        .join(service.get_id_ref()?);
     let mut downloaded = true;
     for file in &service.weights_files.clone().unwrap() {
         let file_path = service_dir.join(file);
@@ -304,11 +327,19 @@ pub async fn is_service_downloaded(service: &Service, app_handle: &AppHandle) ->
                 .head(url)
                 .send()
                 .await
-                .map_err(|_| format!("Failed HEAD request: {}", url))
-                .unwrap();
+                .map_err(|_| format!("Failed HEAD request: {}", url))?;
             if response.status().is_success() {
                 if let Some(remote_file_size) = response.headers().get("Content-Length") {
-                    let parsed_size = remote_file_size.to_str().unwrap().parse::<u64>().unwrap();
+                    let parsed_size = remote_file_size
+                        .to_str()
+                        .with_context(|| "Header value remote_file_size not utf-8")?
+                        .parse::<u64>()
+                        .with_context(|| {
+                            format!(
+                                "Failed to parse header-value({:?}) as u64",
+                                remote_file_size.to_str()
+                            )
+                        })?;
                     // println!("Content-Length: {:?}", parsed_size);
                     if file_size_on_disk != parsed_size {
                         downloaded = false;
@@ -367,7 +398,7 @@ pub async fn update_service_with_dynamic_state(
     let has_enough_total_memory = has_enough_total_memory(service).await?;
     let has_enough_storage = has_enough_storage().await?;
     let is_supported = is_supported().await?;
-    let is_service_running = is_service_running(&service.id.as_ref().unwrap(), &state).await?;
+    let is_service_running = is_service_running(service.get_id_ref()?, &state).await?;
     let base_url = get_base_url(service)?;
     service.downloaded = Some(is_service_downloaded);
     service.enough_memory = Some(has_enough_free_memory);
@@ -383,9 +414,9 @@ pub async fn update_service_with_dynamic_state(
 pub async fn get_system_stats() -> Result<HashMap<String, String>> {
     Ok(HashMap::new())
 }
+
 #[tauri::command(async)]
 pub async fn get_service_stats(service_id: String) -> Result<HashMap<String, String>> {
-    log::info!("service_id: {}", service_id);
     Ok(HashMap::new())
 }
 #[tauri::command(async)]
@@ -396,6 +427,6 @@ pub async fn get_gpu_stats() -> Result<HashMap<String, String>> {
 #[tauri::command(async)]
 pub async fn add_service(service: Service, state: State<'_, SharedState>) -> Result<()> {
     let mut services_guard = state.services.lock().await;
-    services_guard.insert(service.id.clone().unwrap(), service.clone());
+    services_guard.insert(service.get_id()?, service);
     Ok(())
 }

--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -1,7 +1,7 @@
 use crate::errors::{Context, Result};
 use std::collections::HashMap;
 
-use crate::{utils, SharedState};
+use crate::{err, utils, SharedState};
 use futures::StreamExt;
 use serde::Serialize;
 use tauri::{Manager, Runtime, Window};
@@ -175,11 +175,7 @@ impl<R: Runtime> Downloader<R> {
 
         // Check the status for errors.
         if !res.status().is_success() {
-            Err(format!(
-                "GET Request: ({}): ({})",
-                res.status(),
-                url.as_ref()
-            ))?
+            err!("GET Request: ({}): ({})", res.status(), url.as_ref());
         }
 
         // Prepare the destination directories
@@ -211,7 +207,7 @@ impl<R: Runtime> Downloader<R> {
             // Retrieve chunk.
             let mut chunk = match item {
                 Ok(chunk) => chunk,
-                Err(e) => Err(format!("Error while downloading: {:?}", e))?,
+                Err(e) => err!("Error while downloading: {e:?}"),
             };
             let chunk_size = chunk.len() as u64;
 

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -40,3 +40,34 @@ impl serde::Serialize for Error {
         serializer.serialize_str(self.to_string().as_ref())
     }
 }
+
+#[macro_export]
+macro_rules! err {
+    ($($t:tt)*) => {{
+        Err(format!($($t)*))?
+    }};
+}
+
+#[macro_export]
+macro_rules! logerr {
+    ($ar:expr $(,)+ $($t:tt)+) => {{
+        if let Err(e) = $ar {
+            log::error!("{e:?}");
+            log::error!($($t)*);
+        }
+    }};
+    ($ar:expr) => {{
+        if let Err(e) = $ar {
+            log::error!("{e:?}");
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! logsome {
+    ($ar:expr, $($t:tt)*) => {{
+        if ($ar).is_none() {
+            log::error!($($t)*);
+        }
+    }};
+}

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -23,27 +23,37 @@ pub async fn fetch_services_manifests(url: &str, state: Arc<SharedState>) -> Res
     Ok(())
 }
 
-pub fn is_aarch64() -> bool {
+pub const fn is_aarch64() -> bool {
     cfg!(target_arch = "aarch64")
 }
 
-pub fn is_x86_64() -> bool {
+pub const fn is_x86_64() -> bool {
     cfg!(target_arch = "x86_64")
 }
 
+pub const fn is_macos() -> bool {
+    cfg!(target_os = "macos")
+}
+
+pub const fn is_unix() -> bool {
+    cfg!(target_family = "unix")
+}
+
 pub fn get_binary_url(binaries_url: &HashMap<String, Option<String>>) -> Result<String> {
-    if is_aarch64() {
+    if !is_unix() && !is_macos() {
+        err!("Unsupported OS")
+    } else if is_aarch64() && is_macos() {
         binaries_url
             .get("aarch64-apple-darwin")
             .with_context(|| "No binary available for platform")?
             .clone()
-            .with_context(|| "No binary available for platform")
-    } else if is_x86_64() {
+            .with_context(|| "Service not supported on your platform")
+    } else if is_x86_64() && is_macos() {
         binaries_url
             .get("x86_64-apple-darwin")
             .with_context(|| "No binary available for platform")?
             .clone()
-            .with_context(|| "No binary available for platform")
+            .with_context(|| "Service not supported on your platform")
     } else {
         err!("Unsupported architecture")
     }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -2,9 +2,9 @@ use crate::errors::{Context, Result};
 use crate::{err, Service, SharedState};
 use reqwest::get;
 use std::collections::HashMap;
-use tauri::State;
+use std::sync::Arc;
 
-pub async fn fetch_services_manifests(url: &str, state: &State<'_, SharedState>) -> Result<()> {
+pub async fn fetch_services_manifests(url: &str, state: Arc<SharedState>) -> Result<()> {
     let response = get(url)
         .await
         .with_context(|| format!("Couldn't fetch the manifest from {url:?}"))?;

--- a/src/controller/binariesController.ts
+++ b/src/controller/binariesController.ts
@@ -13,10 +13,7 @@ class BinariesController extends AbstractServiceController {
 
   async restart(serviceId: string): Promise<void> {
     await this.stop(serviceId);
-    const services: string[] = await invoke("get_running_services");
-    while (!services.includes(serviceId)) {
-      await this.start(serviceId);
-    }
+    await this.start(serviceId);
   }
 
   async stop(serviceId: string): Promise<void> {


### PR DESCRIPTION
Fixes #406 

---

### Why was stop service not working properly?

SIGKILL is sent by `std::process::Child::kill(&self)` and the FastAPI server is hosted in a child process, hence killing the parent just causes a reparent to current process, and doesn't kill the child process spawned by Python. While killing the prem-app cleans them up.
This is cause, the process groups aren't initialized for `std::process::Command` for grouped signal dispatch.

### Possible Solutions

There are two solutions,
1. Use process groups for each command (CommandGroup?), to broadcast SIGKILL command to the entire process tree for the quiting command.
2. Use SIGTERM instead for then the process will be responsible to handle the resource cleanup, this also ensures no broken resources will be left behind that could be removed by the process.


#### We picked solution 2.

---

Fixes #437 

---

### Ensure on quit operation we gracefully stop all services

This should already be handled because the terminal session will start it in a process group that ensure all the process will be killed if they haven't been detached but currently it doesn't guarantee deterministic behaviour. 

### Possible Solutions

There are two solutions,
1. Before application quit call stop_all_services.
2. Before binary exit or panic of any kind try to call stop_all_services.

#### We picked solution 1 + 2 (just to ensure we always call stop_all_services).

### Cons

Because we handle panics and exits with custom code that code itself "can" "theoritically" panic and cause a panic during a panic, which means a direct abort leading to no stack trace being reported.
This should currently not happen as the code called in such contexts is panic-free, and hence should be safe behaviour but letting people know just in case we ever introduce a panic to the code, it should be easier to debug.