### PR TITLE
fix: match premd routes with slash in docker controller

### DIFF
--- a/src/controller/dockerController.ts
+++ b/src/controller/dockerController.ts
@@ -62,7 +62,7 @@ class DockerController extends AbstractServiceController {
   }
 
   async getServices(): Promise<ServiceDocker[]> {
-    const response = await api().get("v1/services");
+    const response = await api().get("v1/services/");
     return response.data;
   }
 
@@ -76,17 +76,17 @@ class DockerController extends AbstractServiceController {
   }
 
   async getSystemStats(): Promise<Record<string, string>> {
-    const response = await api().get("v1/stats-all");
+    const response = await api().get("v1/stats-all/");
     return response.data;
   }
 
   async getGPUStats(): Promise<Record<string, string>> {
-    const response = await api().get("v1/gpu-stats-all");
+    const response = await api().get("v1/gpu-stats-all/");
     return response.data;
   }
 
   async getInterfaces(): Promise<Interface[]> {
-    const response = await api().get("v1/interfaces");
+    const response = await api().get("v1/interfaces/");
     return response.data;
   }
 


### PR DESCRIPTION
To test run all the services and build the app image from source

```sh
docker-compose -f docker-compose.gateway.yml up -d --build
```

then go to http://localhost:80