### PR TITLE
Remove isFetching

### DIFF
--- a/src/modules/service-detail/components/ServiceDetail.tsx
+++ b/src/modules/service-detail/components/ServiceDetail.tsx
@@ -26,7 +26,7 @@ const ServiceDetail = () => {
     serviceType: Service["serviceType"];
   }>();
   const navigate = useNavigate();
-  const { data: service, isLoading, isFetching, refetch } = useGetService(serviceId!, serviceType!);
+  const { data: service, isLoading, refetch } = useGetService(serviceId!, serviceType!);
 
   const { data: interfaces } = useInterfaces();
 
@@ -39,8 +39,7 @@ const ServiceDetail = () => {
     navigate("/");
   };
 
-  if (isFetching || isLoading || !service || Object.keys(service ?? {}).length === 0)
-    return <ServiceLoading />;
+  if (isLoading || !service || Object.keys(service ?? {}).length === 0) return <ServiceLoading />;
 
   const status = getServiceStatus(service);
 


### PR DESCRIPTION
`isFetching` will be true during background fetch.
`isFetching` use case is to display real-time updates, showing to the user that data are being refreshed.
`isLoading` is sufficient in our use case. Second time we navigate to Detail page, data will be served from cache.