### PR TITLE
GHA: split Tauri and Docker in two workflows

### DIFF
--- a/.github/workflows/on-workflow-dispatch-docker.yaml
+++ b/.github/workflows/on-workflow-dispatch-docker.yaml
@@ -10,7 +10,7 @@ on:
       tag_as_latest:
         description: 'Also tag as latest?'
         required: false
-        default: 'false'
+        default: false
         type: boolean
 
 jobs:

--- a/.github/workflows/on-workflow-dispatch-docker.yaml
+++ b/.github/workflows/on-workflow-dispatch-docker.yaml
@@ -1,6 +1,6 @@
-name: On Push Server
+name: 🚀 Docker Image
 on:
-  push: {branches: [server]}
+  workflow_dispatch:
 jobs:
   push-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-workflow-dispatch-docker.yaml
+++ b/.github/workflows/on-workflow-dispatch-docker.yaml
@@ -1,32 +1,51 @@
 name: 🚀 Docker Image
+
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag for the Docker image (optional, will use latest Git tag if empty)'
+        required: false
+        type: string
+      tag_as_latest:
+        description: 'Also tag as latest?'
+        required: false
+        default: 'false'
+        type: boolean
+
 jobs:
   push-docker-image:
     runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
-    - uses: actions/checkout@v4
-    - name: metadata
-      id: metadata
-      run: |
-        git fetch --all --tags
-        TAG=$(git describe --tags)
-        echo "tag=${TAG/-*}" >> $GITHUB_OUTPUT
-    - uses: docker/setup-qemu-action@v3
-    - uses: docker/setup-buildx-action@v3
-      with:
-        install: true
-    - uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build & push prem
-      run: >-
-        docker buildx build --push
-        --file Dockerfile
-        --tag ghcr.io/premai-io/prem-app:latest
-        --tag ghcr.io/premai-io/prem-app:${{ steps.metadata.outputs.tag }}
-        --platform linux/arm64,linux/amd64 .
+      - uses: actions/checkout@v4
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ -z "${{ github.event.inputs.version }}" ]; then
+            git fetch --all --tags
+            TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          else
+            TAG=${{ github.event.inputs.version }}
+          fi
+          echo "VERSION_TAG=$TAG" >> $GITHUB_ENV
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build & push
+        run: |
+          TAGS="ghcr.io/premai-io/prem-app:$VERSION_TAG"
+          if ${{ github.event.inputs.tag_as_latest }} == 'true'; then
+            TAGS="$TAGS,ghcr.io/premai-io/prem-app:latest"
+          fi
+          docker buildx build --push \
+            --file Dockerfile \
+            --tag $TAGS \
+            --platform linux/arm64,linux/amd64 .

--- a/.github/workflows/on-workflow-dispatch-tauri.yaml
+++ b/.github/workflows/on-workflow-dispatch-tauri.yaml
@@ -1,4 +1,4 @@
-name: Release on user input
+name: 🚀 Dekstop App as Draft
 
 on:
   workflow_dispatch:
@@ -110,7 +110,7 @@ jobs:
           tagName: ${{ github.event.inputs.version }}
           releaseName: "PremAI App ${{ github.event.inputs.version }}"
           releaseBody: "See the assets to download and install this version."
-          releaseDraft: false
+          releaseDraft: true 
           includeDebug: true
           updaterJsonKeepUniversal: true
           args: ${{matrix.platform == 'ubuntu-20.04' && '--target x86_64-unknown-linux-gnu' || '--target universal-apple-darwin'}}

--- a/.github/workflows/on-workflow-dispatch-tauri.yaml
+++ b/.github/workflows/on-workflow-dispatch-tauri.yaml
@@ -1,4 +1,4 @@
-name: 🚀 Dekstop App as Draft
+name: 🚀 Tauri Dekstop App
 
 on:
   workflow_dispatch:

--- a/.github/workflows/on-workflow-dispatch-tauri.yaml
+++ b/.github/workflows/on-workflow-dispatch-tauri.yaml
@@ -4,11 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       branchName:
-        description: 'Branch Name'
+        description: 'Branch Name you are releasing from'
         required: true
       version:
-          description: 'New version'
+          description: 'Version tag for the Github Release and the .dmg for MacOS'
           required: true
+      release_as_draft:
+            description: 'Release as Draft'
+            required: false
+            default: true
+            type: boolean
 
 jobs:
   publish-tauri:
@@ -110,7 +115,7 @@ jobs:
           tagName: ${{ github.event.inputs.version }}
           releaseName: "PremAI App ${{ github.event.inputs.version }}"
           releaseBody: "See the assets to download and install this version."
-          releaseDraft: true 
+          releaseDraft: ${{ github.event.inputs.release_as_draft }} 
           includeDebug: true
           updaterJsonKeepUniversal: true
           args: ${{matrix.platform == 'ubuntu-20.04' && '--target x86_64-unknown-linux-gnu' || '--target universal-apple-darwin'}}


### PR DESCRIPTION
- chore: split tauri and docker image on manual trigger
- chore: add version and latest as options of the trigger
