### PR TITLE
add: handle edge cases & tests for macos

### DIFF
--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -44,17 +44,90 @@ pub fn get_binary_url(binaries_url: &HashMap<String, Option<String>>) -> Result<
         err!("Unsupported OS")
     } else if is_macos() {
         if is_x86_64() {
-            binaries_url.get("x86_64-apple-darwin")
+            binaries_url.get("x86_64-apple-darwin").cloned().flatten()
         } else if is_aarch64() {
-            binaries_url.get("aarch64-apple-darwin")
+            binaries_url.get("aarch64-apple-darwin").cloned().flatten()
         } else {
             err!("Unsupported architecture")
         }
-        .or_else(|| binaries_url.get("universal-apple-darwin"))
-        .with_context(|| "No binary available for platform")?
-        .clone()
+        .or_else(|| {
+            binaries_url
+                .get("universal-apple-darwin")
+                .cloned()
+                .flatten()
+        })
         .with_context(|| "Service not supported on your platform")
     } else {
         err!("Unsupported platform")
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::get_binary_url;
+    use std::collections::HashMap;
+
+    #[test]
+    fn binary_url_test_universal_only() {
+        let url = get_binary_url(&HashMap::from_iter([(
+            "universal-apple-darwin".to_string(),
+            Some("randome_url.com".to_string()),
+        )]))
+        .unwrap();
+        assert_eq!(url, "randome_url.com");
+    }
+
+    #[test]
+    fn binary_url_test_universal_only_option() {
+        let url = get_binary_url(&HashMap::from_iter([
+            (
+                "universal-apple-darwin".to_string(),
+                Some("randome_url.com".to_string()),
+            ),
+            ("aarch64-apple-darwin".to_string(), None),
+            ("x86_64-apple-darwin".to_string(), None),
+        ]))
+        .unwrap();
+        assert_eq!(url, "randome_url.com");
+    }
+
+    #[test]
+    fn binary_url_test_with_non_universal() {
+        let url = get_binary_url(&HashMap::from_iter([
+            (
+                "universal-apple-darwin".to_string(),
+                Some("randome_url.com//universal".to_string()),
+            ),
+            (
+                "aarch64-apple-darwin".to_string(),
+                Some("randome_url.com//not_universal".to_string()),
+            ),
+            (
+                "x86_64-apple-darwin".to_string(),
+                Some("randome_url.com//not_universal".to_string()),
+            ),
+        ]))
+        .unwrap();
+        assert_eq!(url, "randome_url.com//not_universal");
+    }
+
+    #[test]
+    #[should_panic]
+    fn binary_url_test_empty() {
+        let url = get_binary_url(&HashMap::from_iter([])).unwrap();
+        assert_eq!(url, "randome_url.com");
+    }
+
+    #[test]
+    fn binary_url_all_none() {
+        let err = get_binary_url(&HashMap::from_iter([
+            ("universal-apple-darwin".to_string(), None),
+            ("aarch64-apple-darwin".to_string(), None),
+            ("x86_64-apple-darwin".to_string(), None),
+        ]));
+        assert_eq!(
+            err.err().map(|err| err.to_string()).unwrap_or_default(),
+            "Service not supported on your platform"
+        );
     }
 }


### PR DESCRIPTION
Tests currently would only run on macos, but since we don't have a CI it shouldn't be an issue, when we add a CI we should support linux and other platforms as well for these tests.