### PR TITLE
Change naviagtion Dashboard > Service Detail > Playground

### DIFF
--- a/src/modules/service-detail/components/ServiceDetail.tsx
+++ b/src/modules/service-detail/components/ServiceDetail.tsx
@@ -36,7 +36,7 @@ const ServiceDetail = () => {
   }, [queryClient, refetch]);
 
   const back = () => {
-    navigate("/");
+    navigate(-1);
   };
 
   if (isLoading || !service || Object.keys(service ?? {}).length === 0) return <ServiceLoading />;

--- a/src/modules/service/components/StoppedServiceState.tsx
+++ b/src/modules/service/components/StoppedServiceState.tsx
@@ -21,6 +21,7 @@ const StoppedServiceState = ({
   onOpenClick,
   openDeleteModal,
   setOpenDeleteModal,
+  isDetailView,
 }: ServiceStateProps & DeleteModalProps) => {
   const { mutate: deleteMutate, isPending: isDeletePending } = useDeleteService();
   const { mutateAsync: startMutateAsync, isPending: isStartPending } = useStartService();
@@ -70,12 +71,14 @@ const StoppedServiceState = ({
 
   return (
     <>
-      <PrimaryButton
-        className="!rounded-[14px] !px-5 !py-0 !text-[10px] !h-[30px] flex items-center"
-        onClick={onStart}
-      >
-        Open
-      </PrimaryButton>
+      {isDetailView && (
+        <PrimaryButton
+          className="!rounded-[14px] !px-5 !py-0 !text-[10px] !h-[30px] flex items-center"
+          onClick={onStart}
+        >
+          Open
+        </PrimaryButton>
+      )}
       {openDeleteModal && (
         <WarningModal
           icon={<DeleteIcon />}

--- a/src/shared/components/LeftSidebar.tsx
+++ b/src/shared/components/LeftSidebar.tsx
@@ -13,7 +13,7 @@ const LeftSidebar = ({ setHamburgerMenu, children }: LeftSidebarProps) => {
   const navigate = useNavigate();
 
   const onCloseClick = () => {
-    navigate("/");
+    navigate(-1);
   };
 
   return (


### PR DESCRIPTION
- Remove the button **Open** on the card in the gallery
- Force user to enter the Service Detail
- In playground, pops back user to service detail with `navigate(-1)`