### PR TITLE
Prem-Service started on different network

### DIFF
--- a/docker-compose.gateway.yml
+++ b/docker-compose.gateway.yml
@@ -25,6 +25,7 @@ services:
     environment:
       - PREM_REGISTRY_URL=https://raw.githubusercontent.com/premAI-io/prem-registry/main/manifests.json
       - PROXY_ENABLED=True
+      - DOCKER_NETWORK=prem-app_default
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.premd.rule=PathPrefix(`/premd`)"
@@ -106,7 +107,6 @@ services:
     user: root
     environment:
       LETSENCRYPT_PROD: false
-      SERVICES: premd,premapp
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
This starts prem-service on same network as other internal prem services.

This should close  [prem-gateway issue](https://github.com/premAI-io/prem-gateway/issues/29)

@tiero please review.