### PR TITLE
fix: stable beluga as a petals service process not stopping

### DIFF
--- a/src-tauri/src/controller_binaries.rs
+++ b/src-tauri/src/controller_binaries.rs
@@ -229,7 +229,7 @@ async fn _stop_service(
         process.name(),
         process.pid()
     );
-    
+
     drop(running_services_guard);
 
     if !process


### PR DESCRIPTION
use SIGKILL as failsafe when SIGTERM doesn't exit process.